### PR TITLE
refactor: apply optimizations

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -28,9 +28,9 @@ pub enum Value {
 
 impl Display for Value {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match *self {
-            Self::Number(num) => write!(f, "{}", num),
-            Self::Boolean(val) => write!(f, "{}", val),
+        match self {
+            Number(num) => write!(f, "{}", num),
+            Boolean(val) => write!(f, "{}", val),
         }
     }
 }

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1,6 +1,6 @@
 use std::fmt::Display;
 
-use crate::tokens::TokenType;
+use crate::{parser, tokens::TokenType, interpreter::evaluate};
 
 #[derive(Debug)]
 pub enum Node {
@@ -24,6 +24,28 @@ pub enum Node {
 pub enum Value {
     Number(f64),
     Boolean(bool),
+}
+
+impl Value {
+    pub fn from_file(source: &str) -> Result<Self, String> {
+        println!("Interpreting expressions in {}", source);
+        
+        Self::try_from(parser::parse_from_file(source)?)
+    }
+
+    #[inline]
+    pub fn from_input(input: &str) -> Result<Self, String> {
+        Self::try_from(parser::parse_from_input(input)?)
+    }
+}
+
+impl TryFrom<Node> for Value {
+    type Error = String;
+  
+    #[inline]
+    fn try_from(ast: Node) -> Result<Self, Self::Error> {
+        evaluate(&ast)
+    }
 }
 
 impl Display for Value {

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -29,8 +29,8 @@ pub enum Value {
 impl Display for Value {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Number(num) => write!(f, "{}", num),
-            Boolean(val) => write!(f, "{}", val),
+            Self::Number(num) => write!(f, "{}", num),
+            Self::Boolean(val) => write!(f, "{}", val),
         }
     }
 }

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -1,90 +1,54 @@
-use crate::{ast::{Node, Value}, parser, tokens::TokenType};
+use crate::{ast::{Node, Value}, tokens::TokenType};
 
-pub struct Interpreter;
-
-pub trait Compile {
-    type Output;
-
-    fn from_ast(ast: Node) -> Result<Self::Output, String>;
-
-    fn from_file(source: &str) -> Result<Self::Output, String> {
-        println!("Interpreting expressions in {}", source);
-        let ast = parser::parse_from_file(source)?;
-        Ok(Self::from_ast(ast)?)
-    }
-
-    fn from_input(input: &str) -> Result<Self::Output, String> {
-        let ast = parser::parse_from_input(input)?;
-        Ok(Self::from_ast(ast)?)
-    }
-}
-
-impl Compile for Interpreter {
-    type Output = Value;
-
-    fn from_ast(ast: Node) -> Result<Self::Output, String> {
-        let eval = Eval::new();
-        eval.evaluate(&ast)
-    }
-}
-
-struct Eval;
-
-impl Eval {
-    pub fn new() -> Self {
-        Self
-    }
-
-    pub fn evaluate(&self, node: &Node) -> Result<Value, String> {
-        match node {
-            Node::Number(num) => Ok(Value::Number(*num)),
-            Node::Boolean(val) => Ok(Value::Boolean(*val)),
-            Node::UnaryExpr { operator, child } => {
-                match self.evaluate(child)? {
-                    Value::Number(num) => match operator {
-                        TokenType::Minus => Ok(Value::Number(-num)),
-                        TokenType::Plus => Ok(Value::Number(num)),
-                        other => Err(format!("Incompatible operand type (Number) for operation '{}'.", other))
-                    },
-                    Value::Boolean(val) => match operator {
-                        TokenType::Not => Ok(Value::Boolean(!val)),
-                        other => Err(format!("Incompatible operand type (Boolean) for operation '{}'.", other))
-                    }
+pub fn evaluate(node: &Node) -> Result<Value, String> {
+    match node {
+        Node::Number(num) => Ok(Value::Number(*num)),
+        Node::Boolean(val) => Ok(Value::Boolean(*val)),
+        Node::UnaryExpr { operator, child } => {
+            match evaluate(child)? {
+                Value::Number(num) => match operator {
+                    TokenType::Minus => Ok(Value::Number(-num)),
+                    TokenType::Plus => Ok(Value::Number(num)),
+                    other => Err(format!("Incompatible operand type (Number) for operation '{}'.", other))
+                },
+                Value::Boolean(val) => match operator {
+                    TokenType::Not => Ok(Value::Boolean(!val)),
+                    other => Err(format!("Incompatible operand type (Boolean) for operation '{}'.", other))
                 }
             }
-            Node::BinaryExpr { operator, lhs, rhs } => {
-                let rhs = self.evaluate(rhs)?;
-                let lhs = self.evaluate(lhs)?;
-                match (rhs, lhs) {
-                    (Value::Number(rhs), Value::Number(lhs)) => {
-                        match operator {
-                            TokenType::Plus => Ok(Value::Number(lhs + rhs)),
-                            TokenType::Minus => Ok(Value::Number(lhs - rhs)),
-                            TokenType::Star => Ok(Value::Number(lhs * rhs)),
-                            TokenType::Slash => Ok(Value::Number(lhs / rhs)),
-                            TokenType::Carrot => Ok(Value::Number(lhs.powf(rhs))),
-                            TokenType::EqualEqual => Ok(Value::Boolean(lhs == rhs)),
-                            TokenType::NotEqual => Ok(Value::Boolean(lhs != rhs)),
-                            TokenType::LessThan => Ok(Value::Boolean(lhs < rhs)),
-                            TokenType::LessThanEqual => Ok(Value::Boolean(lhs <= rhs)),
-                            TokenType::GreaterThan => Ok(Value::Boolean(lhs > rhs)),
-                            TokenType::GreaterThanEqual => Ok(Value::Boolean(lhs >= rhs)),
-                            other => Err(format!("Cannot apply operator '{}' to two Numbers.", other))
-                        }
-                    },
-                    (Value::Boolean(rhs), Value::Boolean(lhs)) => {
-                        match operator {
-                            TokenType::NotEqual => Ok(Value::Boolean(lhs != rhs)),
-                            TokenType::EqualEqual => Ok(Value::Boolean(lhs == rhs)),
-                            TokenType::Or => Ok(Value::Boolean(lhs || rhs)),
-                            TokenType::And => Ok(Value::Boolean(lhs && rhs)),
-                            other => Err(format!("Cannot apply operator '{}' to two Booleans.", other))
-                        }
-                    }
-                    (rhs, lhs) => Err(format!("Left hand and right hand side of the expression are not of the same type. (Operating on '{:?}' and '{:?}')", rhs, lhs))
-                }
-            }
-            Node::GroupingExpr { child } => self.evaluate(child),
         }
+        Node::BinaryExpr { operator, lhs, rhs } => {
+            let rhs = evaluate(rhs)?;
+            let lhs = evaluate(lhs)?;
+            match (rhs, lhs) {
+                (Value::Number(rhs), Value::Number(lhs)) => {
+                    match operator {
+                        TokenType::Plus => Ok(Value::Number(lhs + rhs)),
+                        TokenType::Minus => Ok(Value::Number(lhs - rhs)),
+                        TokenType::Star => Ok(Value::Number(lhs * rhs)),
+                        TokenType::Slash => Ok(Value::Number(lhs / rhs)),
+                        TokenType::Carrot => Ok(Value::Number(lhs.powf(rhs))),
+                        TokenType::EqualEqual => Ok(Value::Boolean(lhs == rhs)),
+                        TokenType::NotEqual => Ok(Value::Boolean(lhs != rhs)),
+                        TokenType::LessThan => Ok(Value::Boolean(lhs < rhs)),
+                        TokenType::LessThanEqual => Ok(Value::Boolean(lhs <= rhs)),
+                        TokenType::GreaterThan => Ok(Value::Boolean(lhs > rhs)),
+                        TokenType::GreaterThanEqual => Ok(Value::Boolean(lhs >= rhs)),
+                        other => Err(format!("Cannot apply operator '{}' to two Numbers.", other))
+                    }
+                },
+                (Value::Boolean(rhs), Value::Boolean(lhs)) => {
+                    match operator {
+                        TokenType::NotEqual => Ok(Value::Boolean(lhs != rhs)),
+                        TokenType::EqualEqual => Ok(Value::Boolean(lhs == rhs)),
+                        TokenType::Or => Ok(Value::Boolean(lhs || rhs)),
+                        TokenType::And => Ok(Value::Boolean(lhs && rhs)),
+                        other => Err(format!("Cannot apply operator '{}' to two Booleans.", other))
+                    }
+                }
+                (rhs, lhs) => Err(format!("Left hand and right hand side of the expression are not of the same type. (Operating on '{:?}' and '{:?}')", rhs, lhs))
+            }
+        }
+        Node::GroupingExpr { child } => evaluate(child),
     }
 }

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -40,16 +40,15 @@ impl Eval {
             Node::Number(num) => Ok(Value::Number(*num)),
             Node::Boolean(val) => Ok(Value::Boolean(*val)),
             Node::UnaryExpr { operator, child } => {
-                let child = self.evaluate(child)?;
-                match child {
+                match self.evaluate(child)? {
                     Value::Number(num) => match operator {
-                        TokenType::Minus => return Ok(Value::Number(-num)),
-                        TokenType::Plus => return Ok(Value::Number(num)),
-                        other => return Err(format!("Incompatible operand type (Number) for operation '{}'.", other))
+                        TokenType::Minus => Ok(Value::Number(-num)),
+                        TokenType::Plus => Ok(Value::Number(num)),
+                        other => Err(format!("Incompatible operand type (Number) for operation '{}'.", other))
                     },
                     Value::Boolean(val) => match operator {
-                        TokenType::Not => return Ok(Value::Boolean(!val)),
-                        other => return Err(format!("Incompatible operand type (Boolean) for operation '{}'.", other))
+                        TokenType::Not => Ok(Value::Boolean(!val)),
+                        other => Err(format!("Incompatible operand type (Boolean) for operation '{}'.", other))
                     }
                 }
             }
@@ -82,7 +81,7 @@ impl Eval {
                             other => Err(format!("Cannot apply operator '{}' to two Booleans.", other))
                         }
                     }
-                    (rhs, lhs) => return Err(format!("Left hand and right hand side of the expression are not of the same type. (Operating on '{:?}' and '{:?}')", rhs, lhs))
+                    (rhs, lhs) => Err(format!("Left hand and right hand side of the expression are not of the same type. (Operating on '{:?}' and '{:?}')", rhs, lhs))
                 }
             }
             Node::GroupingExpr { child } => self.evaluate(child),

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,20 +28,23 @@ fn main() {
 }
 
 fn repl() {
+    let mut buffer = String::new();
+    
     loop {
         print!(">>> ");
         
         io::stdout().flush().expect("Could not flush stdout.");
-        let mut buffer = String::new();
         
         io::stdin()
             .read_line(&mut buffer)
             .expect("Failed to read input.");
         
-        if buffer.trim().is_empty() {
+        let trimmed = buffer.trim();
+        
+        if trimmed.is_empty() {
             continue;
         } else {
-            eval_input(buffer.trim());
+            eval_input(trimmed);
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,5 @@
 #![deny(rust_2018_idioms)]
 
-use interpreter::Compile;
 use std::io::{self, Write};
 
 mod ast;
@@ -9,6 +8,8 @@ mod parser;
 mod scanner;
 mod tokens;
 
+use ast::Value;
+
 fn main() {
     let mut args = std::env::args();
     args.next().unwrap(); // ignore args[0]
@@ -16,7 +17,7 @@ fn main() {
     match args.next() {
         Some(file) => {
             if file.trim().is_empty() {
-                match interpreter::Interpreter::from_file(&file) {
+                match Value::from_file(&file) {
                     Ok(result) => println!("Result: {}", result),
                     Err(err) => println!("Error: {}", err),
                 }
@@ -50,7 +51,7 @@ fn repl() {
 }
 
 fn eval_input(input: &str) {
-    match interpreter::Interpreter::from_input(input) {
+    match Value::from_input(input) {
         Ok(result) => println!("Result: {}", result),
         Err(err) => println!("Error: {}", err)
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,30 +10,34 @@ mod scanner;
 mod tokens;
 
 fn main() {
-    let args: Vec<String> = std::env::args().collect();
-    if args.len() < 2 {
-        repl();
-    } else if !args[1].trim().is_empty() {
-        match interpreter::Interpreter::from_file(&args[1]) {
-            Ok(result) => {
-                println!("Result: {}", result);
-            }
-            Err(err) => {
-                println!("Error: {}", err);
+    let mut args = std::env::args();
+    args.next().unwrap(); // ignore args[0]
+    
+    match args.next() {
+        Some(file) => {
+            if file.trim().is_empty() {
+                match interpreter::Interpreter::from_file(&file) {
+                    Ok(result) => println!("Result: {}", result),
+                    Err(err) => println!("Error: {}", err),
+                }
             }
         }
+        
+        None => repl(),
     }
 }
 
 fn repl() {
     loop {
         print!(">>> ");
+        
         io::stdout().flush().expect("Could not flush stdout.");
         let mut buffer = String::new();
+        
         io::stdin()
             .read_line(&mut buffer)
-            .ok()
             .expect("Failed to read input.");
+        
         if buffer.trim().is_empty() {
             continue;
         } else {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2,6 +2,7 @@ use crate::ast::Node;
 use crate::scanner;
 use crate::tokens::Token;
 use crate::tokens::TokenType;
+use std::iter::IntoIterator;
 
 pub struct Parser {
     tokens: Vec<Token>,
@@ -32,7 +33,7 @@ impl Parser {
     fn parse_logic_binary(&mut self) -> Result<Node, String> {
         let mut expr = self.parse_term()?;
 
-        while self.match_token(vec![
+        while self.match_token([
             TokenType::GreaterThan,
             TokenType::GreaterThanEqual,
             TokenType::LessThan,
@@ -57,7 +58,7 @@ impl Parser {
     fn parse_term(&mut self) -> Result<Node, String> {
         let mut expr = self.parse_factor()?;
 
-        while self.match_token(vec![TokenType::Plus, TokenType::Minus]) {
+        while self.match_token([TokenType::Plus, TokenType::Minus]) {
             let operator = self.previous().token_type;
             let right = self.parse_factor()?;
             expr = Node::BinaryExpr {
@@ -73,7 +74,7 @@ impl Parser {
     fn parse_factor(&mut self) -> Result<Node, String> {
         let mut expr = self.parse_power()?;
 
-        while self.match_token(vec![TokenType::Star, TokenType::Slash]) {
+        while self.match_token([TokenType::Star, TokenType::Slash]) {
             let operator = self.previous().token_type;
             let right = self.parse_power()?;
             expr = Node::BinaryExpr {
@@ -89,7 +90,7 @@ impl Parser {
     fn parse_power(&mut self) -> Result<Node, String> {
         let mut expr = self.parse_unary()?;
 
-        while self.match_token(vec![TokenType::Carrot]) {
+        while self.match_token([TokenType::Carrot]) {
             let operator = self.previous().token_type;
             let right = self.parse_unary()?;
             expr = Node::BinaryExpr {
@@ -103,7 +104,7 @@ impl Parser {
     }
 
     fn parse_unary(&mut self) -> Result<Node, String> {
-        while self.match_token(vec![TokenType::Minus, TokenType::Not]) {
+        while self.match_token([TokenType::Minus, TokenType::Not]) {
             let operator = self.previous().token_type;
             let expr = self.parse_unary()?;
             return Ok(Node::UnaryExpr {
@@ -155,8 +156,8 @@ impl Parser {
         ))
     }
 
-    fn match_token(&mut self, types: Vec<TokenType>) -> bool {
-        for token_type in types {
+    fn match_token<T: IntoIterator<Item = TokenType>>(&mut self, types: T) -> bool {
+        for token_type in types.into_iter() {
             if self.check(token_type) {
                 self.advance();
                 return true;
@@ -172,6 +173,7 @@ impl Parser {
         token_type == self.get_current().token_type
     }
 
+    #[inline]
     fn is_at_end(&self) -> bool {
         self.get_current().token_type == TokenType::Eof
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -9,10 +9,12 @@ pub struct Parser {
     current: usize,
 }
 
+#[inline]
 pub fn parse_from_file(source: &str) -> Result<Node, String> {
     Parser::new(scanner::scan_from_file(source)?).parse()
 }
 
+#[inline]
 pub fn parse_from_input(input: &str) -> Result<Node, String> {
     Parser::new(scanner::scan_from_input(input)?).parse()
 }
@@ -22,10 +24,12 @@ impl Parser {
         Parser { tokens, current: 0 }
     }
 
+    #[inline]
     pub fn parse(&mut self) -> Result<Node, String> {
         self.parse_expression()
     }
 
+    #[inline]
     fn parse_expression(&mut self) -> Result<Node, String> {
         self.parse_logic_binary()
     }
@@ -182,21 +186,22 @@ impl Parser {
         self.tokens.get(self.current).unwrap().clone()
     }
 
-    fn consume_token(&mut self, token_type: TokenType, message: String) -> Result<Token, String> {
+    fn consume_token(&mut self, token_type: TokenType, message: String) -> Result<(), String> {
         if self.check(token_type) {
-            return Ok(self.advance());
+            self.advance();
+            Ok(())
+        } else {
+            Err(message)
         }
-
-        Err(message)
     }
 
-    fn advance(&mut self) -> Token {
+    fn advance(&mut self) {
         if !self.is_at_end() {
             self.current += 1;
         }
-        self.previous()
     }
 
+    #[inline]
     fn previous(&self) -> Token {
         self.tokens.get(self.current - 1).unwrap().clone()
     }

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -14,7 +14,7 @@ pub struct Scanner<'a> {
 pub fn scan_from_file(source: &str) -> Result<Vec<Token>, String> {
     match fs::read_to_string(source) {
         Ok(content) => return Ok(Scanner::new(content.as_str()).scan_tokens()?),
-        Err(_err) => return Err("Failed to read file!".to_string()),
+        Err(_) => return Err("Failed to read file!".to_string()),
     };
 }
 
@@ -40,7 +40,7 @@ impl<'a> Scanner<'a> {
         }
 
         self.tokens
-            .push(Token::new(TokenType::Eof, String::from(""), self.line));
+            .push(Token::new(TokenType::Eof, String::new(), self.line));
         Ok(self.tokens.clone())
     }
 

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -1,5 +1,4 @@
 use std::fs;
-
 use crate::tokens::Token;
 use crate::tokens::TokenType;
 
@@ -13,20 +12,22 @@ pub struct Scanner<'a> {
 
 pub fn scan_from_file(source: &str) -> Result<Vec<Token>, String> {
     match fs::read_to_string(source) {
-        Ok(content) => return Ok(Scanner::new(content.as_str()).scan_tokens()?),
-        Err(_) => return Err("Failed to read file!".to_string()),
-    };
+        Ok(content) => Scanner::new(content.as_str()).scan_tokens(),
+        Err(_) => Err("Failed to read file!".to_string()),
+    }
 }
 
+#[inline]
 pub fn scan_from_input(input: &str) -> Result<Vec<Token>, String> {
-    return Ok(Scanner::new(input).scan_tokens()?);
+    Scanner::new(input).scan_tokens()
 }
 
 impl<'a> Scanner<'a> {
+    #[inline]
     pub fn new(input: &'a str) -> Self {
-        Scanner {
+        Self {
             input,
-            tokens: vec![],
+            tokens: Vec::new(),
             start: 0,
             current: 0,
             line: 1,
@@ -41,6 +42,7 @@ impl<'a> Scanner<'a> {
 
         self.tokens
             .push(Token::new(TokenType::Eof, String::new(), self.line));
+        
         Ok(self.tokens.clone())
     }
 
@@ -55,9 +57,7 @@ impl<'a> Scanner<'a> {
             '*' => self.add_token(TokenType::Star),
             '/' => self.add_token(TokenType::Slash),
             '^' => self.add_token(TokenType::Carrot),
-            '.' => {
-                self.number()?;
-            }
+            '.' => self.number()?,
 
             '=' => {
                 if self.get_current() == '=' {
@@ -123,6 +123,7 @@ impl<'a> Scanner<'a> {
                 }
             }
         }
+        
         Ok(())
     }
 
@@ -132,7 +133,7 @@ impl<'a> Scanner<'a> {
         }
 
         self.add_token(TokenType::Identifier(
-            self.input[self.start..self.current].to_string(),
+            self.input[self.start..self.current].to_string()
         ))
     }
 
@@ -155,16 +156,18 @@ impl<'a> Scanner<'a> {
         match self.input[self.start..self.current].parse::<f64>() {
             Ok(num) => {
                 self.add_token(TokenType::Number(num));
-                return Ok(());
+                
+                Ok(())
             }
-            _ => return Err("Something went wrong when scanning number token.".to_string()),
-        };
+            
+            _ => Err("Something went wrong when scanning number token.".to_string()),
+        }
     }
 
     fn add_token(&mut self, token_type: TokenType) {
         let text: &str = &self.input[self.start..self.current];
         self.tokens
-            .push(Token::new(token_type, text.to_string(), self.line));
+            .push(Token::new(token_type, String::from(text), self.line));
     }
 
     fn get_current(&self) -> char {


### PR DESCRIPTION
changes in this PR:
- use `TryFrom` trait for conversions that returns a `Result` ([see here](https://doc.rust-lang.org/std/convert/trait.TryFrom.html))
- mark lots of one-liner functions as `inline` using the `#[inline]` attribute to improve performance
- mark small struct constructors as `const` (like C++'s `constexpr`)
- `std::env::args` now only uses the `Iterator` instead of consuming it to a Vector with `.collect()`, because we are only consuming the first and second value for this.
- `match_tokens` now accepts any value implementing the `IntoIterator` trait ([see here](https://doc.rust-lang.org/std/iter/trait.IntoIterator.html)), with this, we can use array literals instead of vectors as arguments.
- Removed unusued return values. (e.g: the `advance` method)
- If a function uses a `match` statement in the end, `=> return ...` can be shortened to just `=> ...`.
- Small refactors in the REPL.
- A bit of code restructuring (see `interpreter.rs` and `ast.rs`)